### PR TITLE
Add support for other implementations (flexi-streams dependency).

### DIFF
--- a/md5.asd
+++ b/md5.asd
@@ -15,5 +15,8 @@
   :maintainer "Pierre R. Mai <pmai@pmsf.de>"
   :licence "Public Domain"
   :version "2.0.2"
-  #+sbcl :depends-on #+sbcl ("sb-rotate-byte")
+  :depends-on (#+sbcl "sb-rotate-byte"
+               #-(or :cmu :sbcl
+                     (and :lispworks (not :lispworks4)) :ccl :allegro)
+               :flexi-streams)
   :components ((:file "md5")))

--- a/md5.lisp
+++ b/md5.lisp
@@ -711,7 +711,8 @@ determined by the underlying implementation."
     #-(or :cmu :sbcl (and :lispworks (not :lispworks4)) :ccl :allegro)
     (if (<= char-code-limit 256)
         (md5sum-sequence string :start start :end end)
-        (error "md5:md5sum-string is not supported for your implementation."))))
+        (md5sum-sequence
+         (flexi-streams:string-to-octets string)))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defconstant +buffer-size+ (* 128 1024)


### PR DESCRIPTION
I'm not sure if you want to add external dependency. Anyways, flexi-streams has generic implementation of #'string-to-octets, which works on implementations not supporting this extension.

If this is too big dependency, I can try to rewrite flexi-streams generic version to fit md5 package (unless public-domain and BSD aren't compatibile, but I think they are).

BR,
Daniel
