### PR TITLE
Fix SBCL byte copy for newer SBCL interface #3

### DIFF
--- a/md5.lisp
+++ b/md5.lisp
@@ -372,7 +372,7 @@ starting from `offset' into the given 16 word MD5 block."
    block (* vm:vector-data-offset vm:word-bits)
    (* 64 vm:byte-bits))
   #+(and :sbcl :little-endian)
-  (sb-kernel:ub8-bash-copy buffer offset block 0 64)
+  (sb-kernel:%byte-blt buffer offset block 0 64)
   #-(or (and :sbcl :little-endian) (and :cmu :little-endian))
   (loop for i of-type (integer 0 16) from 0
         for j of-type (integer 0 #.most-positive-fixnum)
@@ -397,8 +397,6 @@ starting from `offset' into the given 16 word MD5 block."
    buffer (+ (* vm:vector-data-offset vm:word-bits) (* offset vm:byte-bits))
    block (* vm:vector-data-offset vm:word-bits)
    (* 64 vm:byte-bits))
-  #+(and :sbcl :little-endian)
-  (sb-kernel:ub8-bash-copy buffer offset block 0 64)
   #-(or (and :sbcl :little-endian) (and :cmu :little-endian))
   (loop for i of-type (integer 0 16) from 0
         for j of-type (integer 0 #.most-positive-fixnum)


### PR DESCRIPTION
Might switch to defering to sb-md5 version of code shipped with SBCL
going forward, but this should fix the code base for now.