### PR TITLE
Genera requires file attributes instead of (in-package). 

### DIFF
--- a/md5.asd
+++ b/md5.asd
@@ -1,3 +1,4 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; -*-
 ;;;; MD5 --- RFC 1321 The MD5 Message-Digest Algorithm
 
 (cl:in-package #:cl-user)
@@ -20,4 +21,5 @@
                      (and :lispworks (not :lispworks4))
                      :ccl :allegro)
                "flexi-streams")
-  :components ((:file "md5")))
+  :components ((:file "package")
+	       (:file "md5")))

--- a/md5.lisp
+++ b/md5.lisp
@@ -1,3 +1,5 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: MD5 -*-
+
 ;;;; This file implements The MD5 Message-Digest Algorithm, as defined in
 ;;;; RFC 1321 by R. Rivest, published April 1992.
 ;;;;
@@ -55,17 +57,6 @@
 ;;;; This software is "as is", and has no warranty of any kind.  The
 ;;;; authors assume no responsibility for the consequences of any use
 ;;;; of this software.
-
-(cl:defpackage #:md5 (:use #:cl)
-  (:export
-   ;; Low-Level types and functions
-   #:md5-regs #:initial-md5-regs #:md5regs-digest
-   #:update-md5-block #:fill-block #:fill-block-ub8 #:fill-block-char
-   ;; Mid-Level types and functions
-   #:md5-state #:md5-state-p #:make-md5-state
-   #:update-md5-state #:finalize-md5-state
-   ;; High-Level functions on sequences, streams and files
-   #:md5sum-sequence #:md5sum-string #:md5sum-stream #:md5sum-file))
 
 (cl:in-package #:md5)
 

--- a/package.lisp
+++ b/package.lisp
@@ -1,0 +1,13 @@
+;;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-lisp; Package: CL-USER -*-
+
+(cl:defpackage #:md5 (:use #:cl)
+  (:export
+   ;; Low-Level types and functions
+   #:md5-regs #:initial-md5-regs #:md5regs-digest
+   #:update-md5-block #:fill-block #:fill-block-ub8 #:fill-block-char
+   ;; Mid-Level types and functions
+   #:md5-state #:md5-state-p #:make-md5-state
+   #:update-md5-state #:finalize-md5-state
+   ;; High-Level functions on sequences, streams and files
+   #:md5sum-sequence #:md5sum-string #:md5sum-stream #:md5sum-file))
+


### PR DESCRIPTION
Genera doesn't handle packages quite the same way as other systems.  It requires the file attribute to be set.